### PR TITLE
remove overwrite of vocab_scores

### DIFF
--- a/llama2.mojo
+++ b/llama2.mojo
@@ -390,7 +390,6 @@ fn tokenizer_init(inout tok: Tokenizer, inout buf: FileBuf) -> None:
         let slen = read_val_int(buf)
         tok.vocab.store(i, read_val_str(buf, slen))
 
-    tok.vocab_scores = buf.data.offset(buf.offset).bitcast[DType.float32]()
     buf.offset += tok.vocab_size * 4
     return None
 

--- a/llama2.mojo
+++ b/llama2.mojo
@@ -390,7 +390,6 @@ fn tokenizer_init(inout tok: Tokenizer, inout buf: FileBuf) -> None:
         let slen = read_val_int(buf)
         tok.vocab.store(i, read_val_str(buf, slen))
 
-    buf.offset += tok.vocab_size * 4
     return None
 
 


### PR DESCRIPTION
```tok.vocab_scores = buf.data.offset(buf.offset).bitcast[DType.float32]()```  appears to be overwriting the scores with junk data.   `buf.offset` is expected to be at the end of the buffer at that point because all data has been read with the offset advanced by each read.

The `tokenizer.bin` file format can be found [here](https://github.com/karpathy/llama2.c/blob/766a30bc6e9a1c69ce007bb69caabf4c6062f0e9/tokenizer.py#L66).