### PR TITLE
Remove falcon style rope

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,61 @@ Lily said,
 achieved tok/s:  359.66149506346966
 ```
 
+## play with Tinyllama-1.1B-Chat-v0.2
+
+The [TinyLlama](https://github.com/jzhang38/TinyLlama) is a 1.1B Llama model trained on 3 trillion tokens. This compactness allows it to cater to a multitude of applications demanding a restricted computation and memory footprint. This is also the reason why we select it as the first model to support. 
+
+First, navigate to the folder when you keep your projects and clone this repository to this folder:
+```bash
+git clone https://github.com/tairov/llama2.mojo.git
+```
+
+Then, open the repository folder:
+
+```bash
+cd llama2.mojo
+```
+
+Now, let's download the model and the tokenizer
+
+```bash
+wget https://huggingface.co/kirp/TinyLlama-1.1B-Chat-v0.2-bin/resolve/main/tok_tl-chat.bin
+wget https://huggingface.co/kirp/TinyLlama-1.1B-Chat-v0.2-bin/resolve/main/tl-chat.bin
+```
+
+Then, just run the Mojo
+
+```bash
+mojo llama2.mojo tl-chat.bin \
+    -r falcon \
+    -z tok_tl-chat.bin \
+    -n 256 -t 0 -s 100 -i "<|im_start|>user\nGive me a python function to generate Fibonacci sequence<|im_end|>\n<|im_start|>assistant\n"
+```
+
+**example output**
+
+```
+num hardware threads:  6
+SIMD vector width:  16
+checkpoint size:  4400767004 [ 4196 MB ]
+n layers:  22
+vocab size:  32003
+<|im_start|>user
+Give me a python function to generate Fibonacci sequence<|im_end|>
+<|im_start|>assistant
+Sure, here's a Python function that generates the Fibonacci sequence:
+
+def fibonacci(n):
+    if n <= 0:
+        return 0
+    elif n == 1:
+        return 1
+    else:
+        return fibonacci(n-1) + fibonacci(n-2)
+
+This function takes an integer n as a parameter and returns the next Fibonacci number. It uses a recursive approach to calculate the Fibonacci numbers, starting from 0 and working up. The function returns the value it found at the current level of the recursion, which can be either 0 or a Fibonacci number.
+```
+
 ## running via Docker
 
 ```bash

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -3,14 +3,17 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 async def generate(prompt, model_name, seed=0, temperature=0.5, num_tokens=256):
     # stream stout
+    base = ""#"../model/"
+    tokenizer_name = "tokenizer.bin"
+    if model_name == "tl-chat.bin":
+        tokenizer_name = 'tok_tl-chat.bin'
     process = subprocess.Popen(
         [
             "mojo",
             "llama2.mojo",
-            Path(model_name),
+            Path(base + model_name),
             "-s",
             str(seed),
             "-n",
@@ -19,6 +22,8 @@ async def generate(prompt, model_name, seed=0, temperature=0.5, num_tokens=256):
             str(temperature),
             "-i",
             prompt,
+            "-z",
+            Path(base + tokenizer_name)
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -50,13 +55,13 @@ Source: https://github.com/tairov/llama2.mojo
                 randomize=True,
             )
             temperature = gr.Slider(
-                minimum=0.0, maximum=2.0, step=0.01, value=0.5, label="Temperature"
+                minimum=0.0, maximum=2.0, step=0.01, value=0.0, label="Temperature"
             )
             num_tokens = gr.Slider(
                 minimum=1, maximum=256, value=256, label="Number of tokens"
             )
             model_name = gr.Dropdown(
-                ["stories15M.bin", "stories42M.bin", "stories110M.bin"],
+                ["stories15M.bin", "stories42M.bin", "stories110M.bin", "tl-chat.bin"],
                 value="stories15M.bin",
                 label="Model Size",
             )
@@ -69,7 +74,7 @@ Source: https://github.com/tairov/llama2.mojo
     # update maximum number of tokens based on model size
     model_name.change(
         lambda x: gr.update(maximum=1024)
-        if x == "stories110M.bin" or x == "stories42M.bin"
+        if x == "stories110M.bin" or x == "stories42M.bin" or x == "tl-chat.bin"
         else gr.update(maximum=256),
         model_name,
         num_tokens,


### PR DESCRIPTION
All HF llama model are falcon style ROPE and we can convert them to original llama style ROPE with a permutation.
This [pull request](https://github.com/ggerganov/llama.cpp/pull/3364) solve the bug when converting HF **GQA** to gguf format.
I learned idea from it and fix the similar bug in the llama2.c's exports.py. 
Now I successfully convert Tinyllama-1.1B-chat to llama style ROPE. So, we can remove the falcon ROPE part.
I have upload the new export.py and llama2.mojo.

Details:
`python export.py tl-chat.bin --hf PY007/TinyLlama-1.1B-Chat-v0.2 --version 0` to conver the model