### PR TITLE
Optimize transformer loops

### DIFF
--- a/llama2.mojo
+++ b/llama2.mojo
@@ -10,6 +10,7 @@ from random import rand
 from read import BufReader, File
 from runtime.llcl import num_cores, Runtime
 from sys import argv
+from tensor import Tensor, TensorShape, TensorSpec
 
 # The SIMD vector width.
 from sys.info import simdwidthof
@@ -24,113 +25,86 @@ alias PointerString = Pointer[UInt8]
 alias BufferPtrType = DTypePointer[DType.uint8]
 alias BufferPtrFloat32 = DTypePointer[DType.float32]
 alias PointerStrings = Pointer[PointerString]
+alias TensorF32 = Tensor[DType.float32]
 
 
-struct Matrix:
-    var data: BufferPtrFloat32
-    var rows: Int
-    var cols: Int
-    var layers: Int
-    var allocated: Int
+struct TensorSlice:
+    # Provides a view into a tensor representing a 1D slice on its first or first 2 dimensions.
+    # Same function signatures as Tensor but without owning the data.
+    var _data: BufferPtrFloat32
+    var _shape: TensorShape
 
-    fn __init__(inout self, rows: Int, cols: Int):
-        self.data = BufferPtrFloat32.alloc(0)
-        self.rows = rows
-        self.cols = cols
-        self.layers = 1
-        self.allocated = 0
+    fn __init__(inout self, t: TensorF32, layer: Int) raises:
+        let elements_per_layer = t.num_elements() // t.dim(0)
+        self._data = t.data().offset(layer * elements_per_layer)
+        if t.rank() == 2:
+            self._shape = TensorShape(t.dim(1))
+        elif t.rank() == 3:
+            self._shape = TensorShape(t.dim(1), t.dim(2))
+        else:
+            # Compiler complains if _shape not defined
+            self._shape = TensorShape(1)
+            raise Error("TensorSlice: rank greater than 3 not implemented.")
 
-    fn __init__(inout self, cols: Int):
-        self.data = BufferPtrFloat32.alloc(0)
-        self.rows = 1
-        self.layers = 1
-        self.cols = cols
-        self.allocated = 0
+    fn __init__(inout self, t: TensorF32, layer: Int, row: Int) raises:
+        let elements_per_layer = t.num_elements() // t.dim(0)
+        let elements_per_row = elements_per_layer // t.dim(1)
+        self._data = t.data().offset(
+            layer * elements_per_layer + row * elements_per_row
+        )
+        if t.rank() == 3:
+            self._shape = TensorShape(t.dim(2))
+        elif t.rank() == 1:
+            # Compiler complains if _shape not defined
+            self._shape = TensorShape(1)
+            raise Error(
+                "Trying to slice a 1D Tensor by layer and row.  This requires a 3D"
+                " Tensor."
+            )
+        else:
+            # Compiler complains if _shape not defined
+            self._shape = TensorShape(1)
+            raise Error("TensorSlice: rank greater than 3 not implemented.")
 
-    fn __init__(inout self, layers: Int, rows: Int, cols: Int):
-        self.__init__(rows, cols)
-        self.layers = layers
+    fn data(self) -> BufferPtrFloat32:
+        return self._data
 
-    fn __del__(owned self):
-        if self.allocated == 1:
-            self.data.free()
+    fn shape(self) -> TensorShape:
+        return self._shape
 
-    @always_inline
-    fn alloc(inout self, fill: Int = 0):
-        self.data = BufferPtrFloat32.alloc(self.size())
-        self.allocated = 1
-        if fill == 1:
-            self.zero()
+    fn num_elements(self) -> Int:
+        return self._shape.num_elements()
 
-    @always_inline
-    fn alloc_zero(inout self):
-        self.alloc(1)
+    fn dim(self, idx: Int) -> Int:
+        return self._shape[idx]
 
-    @always_inline
-    fn zero(inout self):
-        memset_zero(self.data, self.size())
+    fn rank(self) -> Int:
+        return self._shape.rank()
 
-    @always_inline
-    fn set_buf_ptr(inout self, ptr: BufferPtrFloat32):
-        self.data = ptr
+    fn simd_load[nelts: Int](self, idx: Int) -> SIMD[DType.float32, nelts]:
+        return self._data.simd_load[nelts](idx)
 
-    # set buf ptr with redefined rows, colss
-    fn set_buf_ptr(inout self, ptr: BufferPtrFloat32, rows: Int, cols: Int):
-        self.data = ptr
-        self.rows = rows
-        self.cols = cols
+    fn simd_load[nelts: Int](self, *indices: Int) -> SIMD[DType.float32, nelts]:
+        if len(VariadicList(indices)) > 2:
+            print(
+                "Warning: TensorSlice only supports 1D and 2D indexing.  Results are"
+                " unlikely to be correct."
+            )
+        return self.simd_load[nelts](indices[0] * self._shape[1] + indices[1])
 
-    @always_inline
-    fn size(inout self) -> Int:
-        return self.cols * self.rows * self.layers
+    fn simd_load[
+        nelts: Int
+    ](self, indices: StaticIntTuple[2]) -> SIMD[DType.float32, nelts]:
+        return self._data.simd_load[nelts](indices[0] * self._shape[1] + indices[1])
 
-    @always_inline
-    fn __getitem__(self, y: Int, x: Int) -> Float32:
-        return self.load[1](y, x)
+    fn __getitem__(self, idx: Int) -> SIMD[DType.float32, 1]:
+        return self._data.simd_load[1](idx)
 
-    @always_inline
-    fn __getitem__(self, x: Int) -> Float32:
-        return self.load[1](0, x)
+    fn simd_store[nelts: Int](self, idx: Int, val: SIMD[DType.float32, nelts]):
+        return self._data.simd_store[nelts](idx, val)
 
-    @always_inline
-    fn load[nelts: Int](self, y: Int, x: Int) -> SIMD[DType.float32, nelts]:
-        return self.data.simd_load[nelts](y * self.cols + x)
-
-    @always_inline
-    fn __setitem__(self, y: Int, x: Int, val: Float32):
-        return self.store[1](y, x, val)
-
-    @always_inline
-    fn __setitem__(self, x: Int, val: Float32):
-        return self.store[1](0, x, val)
-
-    @always_inline
-    fn store[nelts: Int](self, y: Int, x: Int, val: SIMD[DType.float32, nelts]):
-        self.data.simd_store[nelts](y * self.cols + x, val)
-
-    @always_inline
-    fn load[nelts: Int](self, x: Int) -> SIMD[DType.float32, nelts]:
-        return self.data.simd_load[nelts](x)
-
-    @always_inline
-    fn store[nelts: Int](self, x: Int, val: SIMD[DType.float32, nelts]):
-        self.data.simd_store[nelts](x, val)
-
-    @always_inline
-    fn __getitem__(self, z: Int, y: Int, x: Int) -> Float32:
-        return self.load[1](z, y, x)
-
-    @always_inline
-    fn load[nelts: Int](self, z: Int, y: Int, x: Int) -> SIMD[DType.float32, nelts]:
-        return self.data.simd_load[nelts](z * self.layers + y * self.cols + x)
-
-    @always_inline
-    fn __setitem__(self, z: Int, y: Int, x: Int, val: Float32):
-        return self.store[1](z, y, x, val)
-
-    @always_inline
-    fn store[nelts: Int](self, z: Int, y: Int, x: Int, val: SIMD[DType.float32, nelts]):
-        self.data.simd_store[nelts](z * self.layers + y * self.cols + x, val)
+    fn __setitem__(self, idx: Int, val: SIMD[DType.float32, 1]):
+        return self.simd_store[1](idx, val)
 
 
 fn read_val_int(inout buf: FileBuf) raises -> Int:
@@ -251,6 +225,9 @@ struct FileBuf:
         self.offset = 0
         self.size = 0
 
+    fn __del__(owned self):
+        self.data.free()
+
     fn move_offset(inout self, size: Int) raises:
         let new_offset = self.offset + size
         if new_offset > self.size:
@@ -259,7 +236,7 @@ struct FileBuf:
             raise Error("Resulting offset will be before the beginning of the FileBuf")
         self.offset = new_offset
 
-    fn bitcast_offset_float32(inout self, size: Int) raises -> BufferPtrFloat32:
+    fn bitcast_offset_f32(inout self, size: Int) raises -> BufferPtrFloat32:
         let ret = self.data.offset(self.offset).bitcast[DType.float32]()
         self.move_offset(size * sizeof[DType.float32]())
         return ret
@@ -273,14 +250,14 @@ struct FileBuf:
 
 
 fn wrap(token: PointerString) -> PointerString:
-    if string_compare(token, str_to_ptr('\\n')) == 0:
-        return str_to_ptr('<0x0A>')
-    if string_compare(token, str_to_ptr('\\t')) == 0:
-        return str_to_ptr('<0x09>')
-    if string_compare(token, str_to_ptr('\'')) == 0:
-        return str_to_ptr('<0x27>')
-    elif string_compare(token, str_to_ptr('\"')) == 0:
-        return str_to_ptr('<0x22>')
+    if string_compare(token, str_to_ptr("\\n")) == 0:
+        return str_to_ptr("<0x0A>")
+    if string_compare(token, str_to_ptr("\\t")) == 0:
+        return str_to_ptr("<0x09>")
+    if string_compare(token, str_to_ptr("'")) == 0:
+        return str_to_ptr("<0x27>")
+    elif string_compare(token, str_to_ptr('"')) == 0:
+        return str_to_ptr("<0x22>")
     return token
 
 
@@ -368,109 +345,87 @@ struct Config:
 
 
 struct RunState:
-    var x: Matrix  # activation at current time stamp (dim,)
-    var xb: Matrix  # same, but inside a residual branch (dim,)
-    var xb2: Matrix  # an additional buffer just for convenience (dim,)
-    var hb: Matrix  # buffer for hidden dimension in the ffn (hidden_dim,)
-    var hb2: Matrix  # buffer for hidden dimension in the ffn (hidden_dim,)
-    var q: Matrix  # query (dim,)
-    var k: Matrix  # key (kv_dim,)
-    var v: Matrix  # value (kv_dim,)
-    var att: Matrix  # buffer for scores/attention values (n_heads, seq_len)
-    var logits: Matrix  # output logits
-    var key_cache: Matrix  # (layer, seq_len, dim)
-    var value_cache: Matrix  # (layer, seq_len, dim)
+    var x: TensorF32  # activation at current time stamp (dim,)
+    var xb: TensorF32  # same, but inside a residual branch (dim,)
+    var xb2: TensorF32  # an additional buffer just for convenience (dim,)
+    var hb: TensorF32  # buffer for hidden dimension in the ffn (hidden_dim,)
+    var hb2: TensorF32  # buffer for hidden dimension in the ffn (hidden_dim,)
+    var q: TensorF32  # query (dim,)
+    var k: TensorSlice  # key (kv_dim,)
+    var v: TensorSlice  # value (kv_dim,)
+    var att: TensorF32  # buffer for scores/attention values (n_heads, seq_len)
+    var logits: TensorF32  # output logits
+    var key_cache: TensorF32  # (layer, seq_len, dim)
+    var value_cache: TensorF32  # (layer, seq_len, dim)
     var rt: Runtime
 
-    fn __init__(inout self, config: Config):
-        self.x = Matrix(config.dim)
-        self.x.alloc_zero()
-        self.xb = Matrix(config.dim)
-        self.xb.alloc_zero()
-        self.xb2 = Matrix(config.dim)
-        self.xb2.alloc_zero()
-        self.hb = Matrix(config.hidden_dim)
-        self.hb.alloc_zero()
-        self.hb2 = Matrix(config.hidden_dim)
-        self.hb2.alloc_zero()
-        self.q = Matrix(config.dim)
-        self.q.alloc_zero()
-        self.k = Matrix(0, 0)
-        self.v = Matrix(0, 0)
-        self.att = Matrix(config.n_heads, config.seq_len)
-        self.att.alloc_zero()
-        self.logits = Matrix(config.vocab_size)
-        self.logits.alloc_zero()
-        self.key_cache = Matrix(config.n_layers, config.seq_len, config.kv_dim)
-        self.key_cache.alloc_zero()
-        self.value_cache = Matrix(config.n_layers, config.seq_len, config.kv_dim)
-        self.value_cache.alloc_zero()
+    fn __init__(inout self, config: Config) raises:
+        self.x = TensorF32(config.dim)
+        self.xb = TensorF32(config.dim)
+        self.xb2 = TensorF32(config.dim)
+        self.hb = TensorF32(config.hidden_dim)
+        self.hb2 = TensorF32(config.hidden_dim)
+        self.q = TensorF32(config.dim)
+        self.att = TensorF32(config.n_heads, config.seq_len)
+        self.logits = TensorF32(config.vocab_size)
+        self.key_cache = TensorF32(config.n_layers, config.seq_len, config.kv_dim)
+        self.value_cache = TensorF32(config.n_layers, config.seq_len, config.kv_dim)
+        # So their updates flow to the caches, k and v are slices with shared memory.
+        # Initialize with placeholders. The real tensors reference layer and position during forward pass.
+        self.k = TensorSlice(TensorF32(TensorShape(1, config.kv_dim)), 1)
+        self.v = TensorSlice(TensorF32(TensorShape(1, config.kv_dim)), 1)
         self.rt = Runtime(num_cores() // 2)
 
 
 struct TransformerWeights:
-    var token_embedding_table: Matrix
-    var freq_cis_real: Matrix
-    var freq_cis_imag: Matrix
-    var rms_att_weight: Matrix
-    var wq: Matrix
-    var wk: Matrix
-    var wv: Matrix
-    var wo: Matrix
-    var rms_ffn_weight: Matrix
-    var w1: Matrix
-    var w3: Matrix
-    var w2: Matrix
-    var rms_final_weight: Matrix
-    var wcls: Matrix
+    var token_embedding_table: TensorF32
+    var freq_cis_real: TensorF32
+    var freq_cis_imag: TensorF32
+    var rms_att_weight: TensorF32
+    var wq: TensorF32
+    var wk: TensorF32
+    var wv: TensorF32
+    var wo: TensorF32
+    var rms_ffn_weight: TensorF32
+    var w1: TensorF32
+    var w3: TensorF32
+    var w2: TensorF32
+    var rms_final_weight: TensorF32
+    var wcls: TensorF32
 
-    fn __init__(inout self, config: Config, shared_weights: Int, inout buf: FileBuf) raises:
-        self.token_embedding_table = Matrix(config.vocab_size, config.dim)
-        # set buf ptr to buf data from file
-        self.token_embedding_table.set_buf_ptr(
-            buf.bitcast_offset_float32(self.token_embedding_table.size())
-        )
-        self.rms_att_weight = Matrix(config.n_layers, config.dim)
-        self.rms_att_weight.set_buf_ptr(
-            buf.bitcast_offset_float32(self.rms_att_weight.size())
-        )
-        self.wq = Matrix(config.n_layers, config.dim, config.dim)
-        self.wq.set_buf_ptr(buf.bitcast_offset_float32(self.wq.size()))
-        self.wk = Matrix(config.n_layers, config.dim, config.kv_dim)
-        self.wk.set_buf_ptr(buf.bitcast_offset_float32(self.wk.size()))
-        self.wv = Matrix(config.n_layers, config.dim, config.kv_dim)
-        self.wv.set_buf_ptr(buf.bitcast_offset_float32(self.wv.size()))
-        self.wo = Matrix(config.n_layers, config.dim, config.dim)
-        self.wo.set_buf_ptr(buf.bitcast_offset_float32(self.wo.size()))
-        self.rms_ffn_weight = Matrix(config.n_layers, config.dim)
-        self.rms_ffn_weight.set_buf_ptr(
-            buf.bitcast_offset_float32(self.rms_ffn_weight.size())
-        )
-        self.w1 = Matrix(config.n_layers, config.dim, config.hidden_dim)
-        self.w1.set_buf_ptr(buf.bitcast_offset_float32(self.w1.size()))
-        self.w2 = Matrix(config.n_layers, config.dim, config.hidden_dim)
-        self.w2.set_buf_ptr(buf.bitcast_offset_float32(self.w2.size()))
-        self.w3 = Matrix(config.n_layers, config.dim, config.hidden_dim)
-        self.w3.set_buf_ptr(buf.bitcast_offset_float32(self.w3.size()))
-        self.rms_final_weight = Matrix(config.dim)
-        self.rms_final_weight.set_buf_ptr(
-            buf.bitcast_offset_float32(self.rms_final_weight.size())
-        )
+    fn __init__(
+        inout self, config: Config, shared_weights: Int, inout buf: FileBuf
+    ) raises:
+        fn load_weights(inout buf: FileBuf, *dims: Int) raises -> TensorF32:
+            # Ensure returned Tensor doesn't share a pointer with FileBuf
+            let shape = TensorShape(dims)
+            let result_data = BufferPtrFloat32.alloc(shape.num_elements())
+            memcpy(
+                result_data,
+                buf.bitcast_offset_f32(shape.num_elements()),
+                shape.num_elements(),
+            )
+            return TensorF32(result_data, shape)
+
+        self.token_embedding_table = load_weights(buf, config.vocab_size, config.dim)
+        self.rms_att_weight = load_weights(buf, config.n_layers, config.dim)
+        self.wq = load_weights(buf, config.n_layers, config.dim, config.dim)
+        self.wk = load_weights(buf, config.n_layers, config.kv_dim, config.dim)
+        self.wv = load_weights(buf, config.n_layers, config.kv_dim, config.dim)
+        self.wo = load_weights(buf, config.n_layers, config.dim, config.dim)
+        self.rms_ffn_weight = load_weights(buf, config.n_layers, config.dim)
+        self.w1 = load_weights(buf, config.n_layers, config.hidden_dim, config.dim)
+        self.w2 = load_weights(buf, config.n_layers, config.dim, config.hidden_dim)
+        self.w3 = load_weights(buf, config.n_layers, config.hidden_dim, config.dim)
+        self.rms_final_weight = load_weights(buf, config.dim)
         # maybe need modifying for different model
         # config.head_size // 2 for stories and tinyllama-1.1
-        self.freq_cis_real = Matrix(config.seq_len, config.head_size // 2)
-        self.freq_cis_real.set_buf_ptr(
-            buf.bitcast_offset_float32(self.freq_cis_real.size())
-        )
-        self.freq_cis_imag = Matrix(config.seq_len, config.head_size // 2)
-        self.freq_cis_imag.set_buf_ptr(
-            buf.bitcast_offset_float32(self.freq_cis_imag.size())
-        )
-        self.wcls = Matrix(config.vocab_size, config.dim)
+        self.freq_cis_real = load_weights(buf, config.seq_len, config.head_size // 2)
+        self.freq_cis_imag = load_weights(buf, config.seq_len, config.head_size // 2)
         if shared_weights:
-            self.wcls.set_buf_ptr(self.token_embedding_table.data)
+            self.wcls = self.token_embedding_table
         else:
-            self.wcls.set_buf_ptr(buf.bitcast_offset_float32(self.wcls.size()))
+            self.wcls = load_weights(buf, config.vocab_size, config.dim)
 
 
 fn read_file(file_name: String, inout buf: FileBuf) raises:
@@ -509,16 +464,18 @@ fn config_init(inout config: Config, inout buf: FileBuf) raises:
     return None
 
 
-fn accum(inout a: BufferPtrFloat32, b: BufferPtrFloat32, size: Int) -> None:
+@always_inline
+fn accum(inout a: TensorF32, b: TensorF32) -> None:
+    let size = a.dim(0)
+
     @parameter
     fn _acc[_nelts: Int](j: Int):
-        a.offset(j).simd_store[_nelts](
-            0, a.offset(j).simd_load[_nelts](0) + b.offset(j).simd_load[_nelts](0)
-        )
+        a.simd_store[_nelts](j, a.simd_load[_nelts](j) + b.simd_load[_nelts](j))
 
     vectorize[nelts, _acc](size)
 
 
+@always_inline
 fn rmsnorm(
     inout o: BufferPtrFloat32, x: BufferPtrFloat32, weight: BufferPtrFloat32, size: Int
 ) -> None:
@@ -547,36 +504,60 @@ fn rmsnorm(
     vectorize[nelts, _norm](size)
 
 
-fn softmax(inout x: BufferPtrFloat32, size: Int) -> None:
-    # Find max value (for numerical stability)
+@always_inline
+fn rmsnorm(inout o: TensorF32, x: TensorF32, weight: TensorF32):
+    rmsnorm(o._ptr, x.data(), weight.data(), weight.dim(weight.rank() - 1))
+
+
+@always_inline
+fn rmsnorm(inout o: TensorF32, x: TensorF32, weight: TensorSlice):
+    rmsnorm(o._ptr, x.data(), weight.data(), weight.dim(weight.rank() - 1))
+
+
+@always_inline
+fn softmax(inout x: TensorF32) -> None:
+    softmax(x, 0, x.dim(0))
+
+
+@always_inline
+fn softmax(inout x: TensorF32, start: Int, end: Int):
     var max_val: Float32 = -1e9
 
     @parameter
-    fn _max[_nelts: Int](j: Int):
-        let val = x.simd_load[_nelts](j).reduce_max()
+    fn _max[_nelts: Int](ii: Int):
+        let val = x.simd_load[_nelts](start + ii).reduce_max()
         if val > max_val:
             max_val = val
 
-    vectorize[nelts, _max](size)
+    vectorize[nelts, _max](end - start)
 
-    # Exp and sum
     var ssum: Float32 = 0.0
 
     @parameter
-    fn _sum_exp[_nelts: Int](j: Int):
-        x.simd_store[_nelts](j, math.exp(x.simd_load[_nelts](j) - max_val))
-        ssum += x.simd_load[_nelts](j).reduce_add()
+    fn _exp[_nelts: Int](ii: Int):
+        x.simd_store[_nelts](
+            start + ii, math.exp(x.simd_load[_nelts](start + ii) - max_val)
+        )
+        ssum += x.simd_load[_nelts](start + ii).reduce_add()
 
-    vectorize[nelts, _sum_exp](size)
+    vectorize[nelts, _exp](end - start)
 
     @parameter
-    fn _norm[_nelts: Int](j: Int):
-        x.simd_store[_nelts](j, x.simd_load[_nelts](j) / ssum)
+    fn _norm[_nelts: Int](ii: Int):
+        x.simd_store[_nelts](start + ii, x.simd_load[_nelts](start + ii) / ssum)
 
-    vectorize[nelts, _norm](size)
+    vectorize[nelts, _norm](end - start)
 
 
-fn matmul_parallelized(C: Matrix, A: Matrix, B: Matrix, rt: Runtime):
+@always_inline
+fn matmul_parallelized(
+    C: BufferPtrFloat32,
+    A: BufferPtrFloat32,
+    B: BufferPtrFloat32,
+    rows: Int,
+    cols: Int,
+    rt: Runtime,
+):
     @parameter
     fn compute_row(i: Int):
         var tmp = SIMD[DType.float32, nelts](0)
@@ -584,44 +565,73 @@ fn matmul_parallelized(C: Matrix, A: Matrix, B: Matrix, rt: Runtime):
         @parameter
         fn dot[_nelts: Int](j: Int):
             if _nelts < nelts:  # take care of tail array elements with length <  nelts
-                tmp[0] += (A.load[_nelts](j) * B.load[_nelts](i, j)).reduce_add()
+                tmp[0] += (
+                    A.simd_load[_nelts](j) * B.simd_load[_nelts](i * cols + j)
+                ).reduce_add()
             else:
-                tmp += A.load[nelts](j) * B.load[nelts](i, j)
+                tmp += A.simd_load[nelts](j) * B.simd_load[nelts](i * cols + j)
 
-        vectorize[nelts, dot](B.cols)
-        C[i] = tmp.reduce_add()
+        vectorize[nelts, dot](cols)
+        C.store(i, tmp.reduce_add())
 
-    parallelize[compute_row](rt, B.rows, rt.parallelism_level())
+    parallelize[compute_row](rt, rows, rt.parallelism_level())
 
 
-fn matmul(inout C: Matrix, A: Matrix, B: Matrix, rt: Runtime) -> None:
+@always_inline
+fn matmul(C: TensorF32, A: TensorF32, B: TensorF32, rt: Runtime) raises:
     # B (d,n) @ A (n,) -> C (d,)
-    matmul_parallelized(C, A, B, rt)
+    matmul_dimension_checks(A.shape(), B.shape())
+    matmul_parallelized(C.data(), A.data(), B.data(), B.dim(0), B.dim(1), rt)
+
+
+@always_inline
+fn matmul(C: TensorF32, A: TensorF32, B: TensorSlice, rt: Runtime) raises:
+    # B (d,n) @ A (n,) -> C (d,)
+    matmul_dimension_checks(A.shape(), B.shape())
+    matmul_parallelized(C.data(), A.data(), B.data(), B.dim(0), B.dim(1), rt)
+
+
+@always_inline
+fn matmul(C: TensorSlice, A: TensorF32, B: TensorSlice, rt: Runtime) raises:
+    # B (d,n) @ A (n,) -> C (d,)
+    matmul_dimension_checks(A.shape(), B.shape())
+    matmul_parallelized(C.data(), A.data(), B.data(), B.dim(0), B.dim(1), rt)
+
+
+fn matmul_dimension_checks(a: TensorShape, b: TensorShape) raises:
+    if a[0] != b[1]:
+        raise Error(
+            "matmul dimension mismatch. A rows (dim 0) not equal to B columns (dim 1)"
+        )
+    if b.rank() != 2:
+        raise Error("matmul expects B to be a 2D matrix")
 
 
 # Apply RoPE rotation to the q and k vectors for each head
 # rotate odd and even dim
-fn rope_rotation_llama(inout state: RunState, freq_cis_real_row: BufferPtrFloat32,
-                         freq_cis_imag_row: BufferPtrFloat32, config: Config) -> None:
-    # stories model, llama2c
-    let q = state.q.data
-    let k = state.k.data
+@always_inline
+fn rope_rotation_llama(
+    inout state: RunState,
+    freq_cis_real_row: TensorSlice,
+    freq_cis_imag_row: TensorSlice,
+    config: Config,
+) -> None:
+    # stories model, llama2
     let head_size = config.head_size
     for i in range(config.n_heads):
         for j in range(0, config.head_size, 2):
-            let fcr = freq_cis_real_row.offset(j // 2).load(0)
-            let fci = freq_cis_imag_row.offset(j // 2).load(0)
-            let q0 = q.offset(i * head_size + j).load(0)
-            let q1 = q.offset(i * head_size + j + 1).load(0)
-            q.offset(i * head_size + j).store(0, q0 * fcr - q1 * fci)
-            q.offset(i * head_size + j + 1).store(0, q0 * fci + q1 * fcr)
+            let fcr = freq_cis_real_row[j // 2]
+            let fci = freq_cis_imag_row[j // 2]
+            let q0 = state.q[i * head_size + j]
+            let q1 = state.q[i * head_size + j + 1]
+            state.q[i * head_size + j] = q0 * fcr - q1 * fci
+            state.q[i * head_size + j + 1] = q0 * fci + q1 * fcr
             if i < config.n_kv_heads:
-                let k0 = k.offset(i * head_size + j).load(0)
-                let k1 = k.offset(i * head_size + j + 1).load(0)
-                k.offset(i * head_size + j).store(0, k0 * fcr - k1 * fci)
-                k.offset(i * head_size + j + 1).store(
-                    0, k0 * fci + k1 * fcr
-                )
+                let k0 = state.k[i * head_size + j]
+                let k1 = state.k[i * head_size + j + 1]
+                state.k[i * head_size + j] = k0 * fcr - k1 * fci
+                state.k[i * head_size + j + 1] = k0 * fci + k1 * fcr
+
 
 @always_inline
 fn transformer(
@@ -630,105 +640,91 @@ fn transformer(
     config: Config,
     inout state: RunState,
     weights: TransformerWeights,
-) -> None:
+) raises -> None:
     # A few convenience variables
-    var x = state.x.data
     let dim = config.dim
     let hidden_dim = config.hidden_dim
     let head_size = config.head_size
     let kv_dim = config.kv_dim
     let kv_mul = config.kv_mul
 
-    # tmp matrix for matmul operations
-    var tmpw = Matrix(0, 0)
-
     # Copy the token embedding into x
-    let content_row = weights.token_embedding_table.data.offset(token * dim)
-    memcpy[DType.float32](x, content_row, config.dim)
+    let content_row = weights.token_embedding_table.data().offset(token * dim)
+    memcpy[DType.float32](state.x.data(), content_row, dim)
 
     # Pluck out the "pos" row of freq_cis_real and freq_cis_imag
-    let freq_cis_real_row = weights.freq_cis_real.data.offset(pos * head_size // 2)
-    let freq_cis_imag_row = weights.freq_cis_imag.data.offset(pos * head_size // 2)
+    let freq_cis_real_row = TensorSlice(weights.freq_cis_real, pos)
+    let freq_cis_imag_row = TensorSlice(weights.freq_cis_imag, pos)
 
     # Forward all the layers
     for l in range(config.n_layers):
         # Attention rmsnorm
-        rmsnorm(state.xb.data, x, weights.rms_att_weight.data.offset(l * dim), dim)
-
+        rmsnorm(state.xb, state.x, TensorSlice(weights.rms_att_weight, l))
         # QKV matmuls for this position
-        tmpw.set_buf_ptr(weights.wq.data.offset(l * dim * dim), dim, dim)
-        matmul(state.q, state.xb, tmpw, state.rt)
+        matmul(state.q, state.xb, TensorSlice(weights.wq, l), state.rt)
 
-        let loff = l * config.seq_len * kv_dim
-        state.k.set_buf_ptr(state.key_cache.data.offset(loff + pos * kv_dim), 1, kv_dim)
-        tmpw.set_buf_ptr(weights.wk.data.offset(l * dim * kv_dim), kv_dim, dim)
-        matmul(state.k, state.xb, tmpw, state.rt)
+        let loff = l * config.seq_len * config.kv_dim
+        state.k = TensorSlice(state.key_cache, l, pos)
+        matmul(state.k, state.xb, TensorSlice(weights.wk, l), state.rt)
 
-        state.v.set_buf_ptr(
-            state.value_cache.data.offset(loff + pos * kv_dim), 1, kv_dim
-        )
-        tmpw.set_buf_ptr(weights.wv.data.offset(l * dim * kv_dim), kv_dim, dim)
-        matmul(state.v, state.xb, tmpw, state.rt)
+        state.v = TensorSlice(state.value_cache, l, pos)
+        matmul(state.v, state.xb, TensorSlice(weights.wv, l), state.rt)
 
         # Apply RoPE rotation to the q and k vectors for each head
         rope_rotation_llama(state, freq_cis_real_row, freq_cis_imag_row, config)
 
+        memset_zero(state.xb.data(), state.xb.num_elements())
         # Multihead attention. Iterate over all heads
         for h in range(config.n_heads):
             # Get the query vector for this head
-            let q = state.q.data.offset(h * head_size)
+            let q_offset = h * head_size
 
-            # Attention scores for this head
-            var att = state.att.data.offset(h * config.seq_len)
+            # Index of attention scores for this head
+            let att_offset = h * config.seq_len
 
             # Iterate over all timesteps, including the current one
             for t in range(pos + 1):
-                # Get the key vector for this head and at this timestep
-                let k = state.key_cache.data.offset(
-                    loff + t * kv_dim + (h // kv_mul) * head_size
-                )
+                # Starting index of the key vector for this head and at this timestep
+                let k_offset = loff + t * kv_dim + (h // kv_mul) * head_size
                 # Calculate the attention score as the dot product of q and k
                 var score: Float32 = 0.0
                 for i in range(head_size):
-                    score += q.offset(i).load(0) * k.offset(i).load(0)
+                    score += state.q[q_offset + i] * state.key_cache[k_offset + i]
+
                 score /= math.sqrt[DType.float32, 1](head_size)
 
                 # Save the score to the attention buffer
-                att.offset(t).store(0, score)
+                state.att[att_offset + t] = score
 
             # Softmax the scores to get attention weights, from 0..pos inclusively
-            softmax(att, pos + 1)
-
+            softmax(state.att, att_offset, att_offset + pos + 1)
             # Weighted sum of the values, store back into xb
-            let xb = state.xb.data.offset(h * head_size)
-            memset_zero(xb, head_size)
+            let xb_offset = h * head_size
             for t in range(pos + 1):
-                # Get the value vector for this head and at this timestep
-                let v = state.value_cache.data.offset(
-                    loff + t * kv_dim + (h // kv_mul) * head_size
-                )
+                # Starting index of the value vector for this head and at this timestep
+                let v_offset = loff + t * kv_dim + (h // kv_mul) * head_size
+
                 # Get the attention weight for this timestep
-                let a = att.offset(t).load(0)
+                let a = state.att[att_offset + t]
                 # Accumulate the weighted value into xb
+
                 for i in range(head_size):
-                    let xbi = xb.offset(i).load(0) + a * v.offset(i).load(0)
-                    xb.offset(i).store(0, xbi)
+                    let xbi = state.xb[xb_offset + i] + a * state.value_cache[
+                        v_offset + i
+                    ]
+                    state.xb[xb_offset + i] = xbi
+
         # Final matrix multiplication to get the output of the attention
-        tmpw.set_buf_ptr(weights.wo.data.offset(l * dim * dim), dim, dim)
-        matmul(state.xb2, state.xb, tmpw, state.rt)
-
+        matmul(state.xb2, state.xb, TensorSlice(weights.wo, l), state.rt)
         # Residual connection back into x
-        accum(x, state.xb2.data, dim)
-
+        accum(state.x, state.xb2)
         # FFN rmsnorm
-        rmsnorm(state.xb.data, x, weights.rms_ffn_weight.data.offset(l * dim), dim)
+        rmsnorm(state.xb, state.x, TensorSlice(weights.rms_ffn_weight, l))
 
         # Calculate self.w1(x) and self.w3(x) for FFN
-        tmpw.set_buf_ptr(weights.w1.data.offset(l * dim * hidden_dim), hidden_dim, dim)
-        matmul(state.hb, state.xb, tmpw, state.rt)
+        matmul(state.hb, state.xb, TensorSlice(weights.w1, l), state.rt)
 
-        tmpw.set_buf_ptr(weights.w3.data.offset(l * dim * hidden_dim), hidden_dim, dim)
-        matmul(state.hb2, state.xb, tmpw, state.rt)
+        matmul(state.hb2, state.xb, TensorSlice(weights.w3, l), state.rt)
 
         # Apply SiLU activation function (silu(x) = x * sigmoid(x))
         for i in range(hidden_dim):
@@ -740,33 +736,31 @@ fn transformer(
             state.hb[i] = state.hb[i] * state.hb2[i]
 
         # Final matrix multiplication to get the output of the FFN
-        tmpw.set_buf_ptr(weights.w2.data.offset(l * dim * hidden_dim), dim, hidden_dim)
-        matmul(state.xb, state.hb, tmpw, state.rt)
+        matmul(state.xb, state.hb, TensorSlice(weights.w2, l), state.rt)
 
         # Residual connection
-        accum(x, state.xb.data, dim)
+        accum(state.x, state.xb)
 
     # Final rmsnorm
-    rmsnorm(x, x, weights.rms_final_weight.data, dim)
+    rmsnorm(state.x, state.x, weights.rms_final_weight)
 
     # Classifier into logits
-    tmpw.set_buf_ptr(weights.wcls.data, config.vocab_size, dim)
-    matmul(state.logits, state.x, tmpw, state.rt)
+    matmul(state.logits, state.x, weights.wcls, state.rt)
 
 
-fn argmax(v: Matrix) -> Int:
+fn argmax(v: TensorF32) -> Int:
     # return argmax of v
     var max_i: Int = 0
     var max_p: Float32 = v[0]
-    for i in range(v.cols):
+    for i in range(v.dim(0)):
         if v[i] > max_p:
             max_i = i
             max_p = v[i]
     return max_i
 
 
-fn sample(probabilities: Matrix) -> Int:
-    let n = probabilities.cols
+fn sample(probabilities: TensorF32) -> Int:
+    let n = probabilities.dim(0)
     # Sample index from probabilities, they must sum to 1
     # get random value within (min, max) float32 range
     let r = DTypePointer[DType.float32].alloc(1)
@@ -899,6 +893,7 @@ fn main() raises:
                     print("Wrong temperature value", temperature)
                     return 0
         return 1
+
     let res = argparse()
     if res == 0:
         print_usage()
@@ -930,7 +925,7 @@ fn main() raises:
 
     # print the layers number and vocab size
     print("n layers: ", config.n_layers)
-    print('vocab size: ', tok.vocab_size)
+    print("vocab size: ", tok.vocab_size)
 
     # Create and initialize the application RunState
     var state = RunState(config)
@@ -965,7 +960,7 @@ fn main() raises:
                 for q in range(config.vocab_size):
                     state.logits[q] = state.logits[q] / temperature
                 # Apply softmax to the logits to get the probabilities for the next token
-                softmax(state.logits.data, config.vocab_size)
+                softmax(state.logits)
                 # Sample from this distribution to get the next token
                 next_token = sample(state.logits)
 


### PR DESCRIPTION
Marked as draft because I built off of the PR #38 branch.

This gets about a 25% speed up by using Mojo's `parallelize` and `vectorize` on the loops in the transformer forward pass.  I also removed the division of `num_cores()` by two but the speed up was apples to apples comparisons of both versions running with all cores.  This was on an 8 core Codespace instance.

Looking at the last commit (to ignore the shift to Tensors) you can see it is just applying the standard for-loop to parallelize (or vectorise) conversion in a some key places.  The main impact is making the loops over attention heads parallel.  Those loops have other loops nested within.  So I believe the biggest impact is from changing 4 lines of code.  So whether the shift to Tensors is adopted or not adding these optimisations is probably worth doing.

