### PR TITLE
✂️ remove call to external os library

### DIFF
--- a/llama2.mojo
+++ b/llama2.mojo
@@ -5,7 +5,6 @@ from math import round
 from memory import memset_zero, memcpy
 from memory.buffer import Buffer
 from memory.unsafe import DTypePointer
-from python import Python
 from random import rand
 from read import BufReader, File
 from runtime.llcl import num_cores, Runtime
@@ -431,10 +430,10 @@ struct TransformerWeights:
 
 
 fn read_file(file_name: String, inout buf: FileBuf) raises:
-    let _os = Python.import_module("os")
-    let ff_size = _os.path.getsize(file_name)
-    let cp_size = string.atol(ff_size.to_string())
-    let cp_buf: BufferPtrType = BufferPtrType.alloc(cp_size)
+    let ff = open(file_name, "r")
+    let ff_size = len(ff.read())
+    ff.close()
+    let cp_buf: BufferPtrType = BufferPtrType.alloc(ff_size)
     # set window buffer to read binary data from file
     let f = File(file_name)
     var reader = BufReader[4096](f ^)
@@ -447,7 +446,7 @@ fn read_file(file_name: String, inout buf: FileBuf) raises:
         offset += bytes_read
     reader.do_nothing()  # keeps lifetimes working
     buf.data = cp_buf
-    buf.size = cp_size
+    buf.size = ff_size
     buf.offset = 0
     return None
 

--- a/llama2.mojo
+++ b/llama2.mojo
@@ -430,7 +430,7 @@ struct TransformerWeights:
 
 
 fn read_file(file_name: String, inout buf: FileBuf) raises:
-    let ff = open(file_name, "r")
+    var ff = open(file_name, "r")
     let ff_size = len(ff.read())
     ff.close()
     let cp_buf: BufferPtrType = BufferPtrType.alloc(ff_size)


### PR DESCRIPTION
I had this issue #53 when trying to run the demo in the README.
Removing the need for the external python os call fixed it and I think this is generally an improvement to the project!
Have not measured it but this will probaply decrease the size binary when building and it removes the need of having a working python installation.

Great project tho now I can experiment with it!