### PR TITLE
bugfix: Dockerfile Modular Auth + Conda env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,31 +34,33 @@ RUN apt-get update \
     curl \ 
     python3 \
     pip \
-    wget \
-    && python3 -m pip install \
-    jupyterlab \
-    ipykernel \
-    matplotlib \
-    ipywidgets \
-    gradio 
+    wget
 
 RUN curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py38_23.5.2-0-Linux-x86_64.sh > /tmp/miniconda.sh \
     && chmod +x /tmp/miniconda.sh \
     && /tmp/miniconda.sh -b -p /opt/conda
 
+ENV PATH=/opt/conda/bin:$PATH
+RUN conda init
+
 ARG AUTH_KEY=DEFAULT_KEY
 ENV AUTH_KEY=$AUTH_KEY
 
-RUN curl https://get.modular.com | MODULAR_AUTH=$AUTH_KEY sh - \
-    && modular install mojo 
+RUN curl https://get.modular.com | MODULAR_AUTH=$AUTH_KEY sh -
+RUN modular auth $AUTH_KEY && \
+    modular install mojo 
 
 RUN useradd -m -u 1000 user
 RUN chown -R user $MODULAR_HOME
 
-ENV PATH="$PATH:/opt/conda/bin:$MODULAR_HOME/pkg/packages.modular.com_mojo/bin"
+ENV PATH="$MODULAR_HOME/pkg/packages.modular.com_mojo/bin:$PATH"
 
-RUN conda init 
-RUN pip install gradio
+RUN pip install \
+    jupyterlab \
+    ipykernel \
+    matplotlib \
+    ipywidgets \
+    gradio 
 
 USER user
 WORKDIR $HOME/app


### PR DESCRIPTION
First of all: Amazing jog! Congrats!
---

I had some errors when I tried to run the Docker version. When I fix the first, the second appears:
1. The authentication fails. I believe Modular changes the way authentication works.
2. Mojo tries to use VENV but "conda init" is called after that.

**My Setup:**
- Intel  i5-13600K
- 32 GB RAM
- WSL2 Ubuntu 22.04 LTS
- Windows 11 Pro Insider Preview x64 (v. 22H2  Build Windows 11 Pro Insider Preview)
- Docker Desktop 4.22.0 (117440)

**Replicating Steps:**
Inside Repo Directory:
```
docker build --build-arg AUTH_KEY=MY_MODULAR_KEY -t llama2.mojo .
```

Terminal Print (Error 1):
```
17.15 Setting up modular (0.2.1) ...
17.16 Processing triggers for libc-bin (2.31-0ubuntu9.12) ...
17.18 sh: 80: [[: not found
17.18   __  __           _       _
17.18  |  \/  | ___   __| |_   _| | __ _ _ __
17.18  | |\/| |/ _ \ / _` | | | | |/ _` | '__|
17.18  | |  | | (_) | (_| | |_| | | (_| | |
17.18  |_|  |_|\___/ \__,_|\__,_|_|\__,_|_|
17.18 
17.18 Welcome to the Modular CLI!
17.18 For info about this tool, type "modular --help".
17.18 
17.18 To install Mojo🔥, type "modular install mojo".
17.18 
17.18 For Mojo documentation, see https://docs.modular.com/mojo.
17.18 To chat on Discord, visit https://discord.gg/modular.
17.18 To report issues, go to https://github.com/modularml/mojo/issues.
21.66 modular: error: please run `modular auth` before attempting to install a package
------
Dockerfile:52
--------------------
  51 |     
  52 | >>> RUN curl https://get.modular.com | MODULAR_AUTH=$AUTH_KEY sh - \
  53 | >>>     && modular install mojo 
  54 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c curl https://get.modular.com | MODULAR_AUTH=$AUTH_KEY sh -     && modular install mojo" did not complete successfully: exit code: 1
```

Terminal Print (Error 2):
```
 => ERROR [ 6/15] RUN modular install mojo                                                                                                                                                                40.6s 
------                                                                                                                                                                                                          
 > [ 6/15] RUN modular install mojo:                                                                                                                                                                            
40.33 The virtual environment was not created successfully because ensurepip is not                                                                                                                             
40.33 available.  On Debian/Ubuntu systems, you need to install the python3-venv
40.33 package using the following command.
40.33 
40.33     apt install python3.8-venv
40.33 
40.33 You may need to use sudo with that command.  After installing the python3-venv
40.33 package, recreate your virtual environment.
40.33 
40.33 Failing command: ['/home/user/.modular/pkg/packages.modular.com_mojo/venv/bin/python3', '-Im', 'ensurepip', '--upgrade', '--default-pip']
40.33 
40.56 modular: error: failed to run python: 
40.56 # Found release for https://packages.modular.com/mojo @ 0.4.0
40.56 # Installing to /home/user/.modular/pkg/packages.modular.com_mojo
40.56 # Downloading artifacts. Please wait...
40.56 # Downloads complete, setting configs...
40.56 # Configs complete, running post-install hooks...
------
Dockerfile:54
--------------------
  52 |     RUN curl https://get.modular.com | MODULAR_AUTH=$AUTH_KEY sh -
  53 |     RUN modular auth $AUTH_KEY
  54 | >>> RUN modular install mojo 
  55 |     
  56 |     RUN useradd -m -u 1000 user
--------------------
ERROR: failed to solve: process "/bin/sh -c modular install mojo" did not complete successfully: exit code: 1
```