### PR TITLE
Update Mojo to v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Have you ever wanted to inference a baby Llama 2 model in pure Mojo? No? Well, now you can!
 
-supported version: [Mojo 0.4.0](https://docs.modular.com/mojo/changelog.html#v0.4.0-2023-10-05)
+supported version: [Mojo 0.5.0](https://docs.modular.com/mojo/changelog.html#v0.5.0-2023-11-2)
 
 With the release of [Mojo](https://www.modular.com/blog/mojo-its-finally-here), I was inspired to take my Python port
 of [llama2.py](https://github.com/tairov/llama2.py) and transition it to Mojo. The result? A version that leverages

--- a/read/__init__.mojo
+++ b/read/__init__.mojo
@@ -96,7 +96,7 @@ struct File:
 
     fn read[D: Dim](self, buffer: Buffer[D, DType.uint8]) raises -> Int:
         return fread(
-            buffer.data.as_scalar_pointer(), sizeof[UInt8](), BUF_SIZE, self.handle
+            buffer.data._as_scalar_pointer(), sizeof[UInt8](), BUF_SIZE, self.handle
         ).to_int()
 
 


### PR DESCRIPTION
Fixed error happen on run with Mojo v0.5.0:
```
$ mojo -v
mojo 0.5.0 (6e50a738)
$ mojo llama2.mojo stories15M.bin -s 100 -n 256 -t 0.5 -i "Mojo is a language"
./llama2.mojo/read/__init__.mojo:99:24: error: 'DTypePointer[ui8]' value has no attribute 'as_scalar_pointer'
            buffer.data.as_scalar_pointer(), sizeof[UInt8](), BUF_SIZE, self.handle
            ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
mojo: error: failed to parse the provided Mojo
```