### PR TITLE
improve readability in batch_matmul

### DIFF
--- a/llama2.mojo
+++ b/llama2.mojo
@@ -2,7 +2,7 @@ from algorithm import sum
 from algorithm import vectorize, parallelize, unroll
 from builtin import string
 from math import round
-from memory import memset_zero, memcpy
+from memory import memset_zero, memcpy, stack_allocation
 from memory.buffer import Buffer
 from memory.unsafe import DTypePointer
 from random import rand
@@ -26,6 +26,31 @@ alias BufferPtrType = DTypePointer[DType.uint8]
 alias BufferPtrFloat32 = DTypePointer[DType.float32]
 alias PointerStrings = Pointer[PointerString]
 alias TensorF32 = Tensor[DType.float32]
+
+
+@register_passable
+struct Accumulator[T: DType, width: Int]:
+    # ideally this could be SIMD[T, width] but the width
+    # in accumulate() method is compared by identity
+    var data: DTypePointer[T]
+
+    @always_inline
+    fn __init__() -> Self:
+        # allocate a DTypePointer on stack that doesn't need to be freed.
+        let data = stack_allocation[width, T]()
+        memset_zero(data, width)
+        return Self {data: data}
+
+    @always_inline
+    fn accumulate[_width: Int](inout self, val: SIMD[T, _width]) -> None:
+        # This is a hack to make sure both SIMD have _width length.
+        # SIMD[T, width] += SIMD[T, _width] is always an error.
+        let newVal = self.data.simd_load[_width]() + val
+        self.data.simd_store[_width](newVal)
+
+    @always_inline
+    fn total(self) -> SIMD[T, 1]:
+        return self.data.simd_load[width]().reduce_add()
 
 
 struct TensorSlice:
@@ -492,18 +517,15 @@ fn rmsnorm(
     inout o: BufferPtrFloat32, x: BufferPtrFloat32, weight: BufferPtrFloat32, size: Int
 ) -> None:
     # Calculate sum of squares
-    var tmp = SIMD[DType.float32, nelts](0)
+    var tmp = Accumulator[DType.float32, nelts]()
 
     @parameter
     fn _sum2[_nelts: Int](j: Int):
-        if _nelts < nelts:
-            tmp[0] += (x.offset(j).simd_load[_nelts](0) ** 2).reduce_add()
-        else:
-            tmp += x.offset(j).simd_load[nelts](0) ** 2
+        tmp.accumulate(x.offset(j).simd_load[_nelts](0) ** 2)
 
     vectorize[nelts, _sum2](size)
 
-    var ss: Float32 = tmp.reduce_add()
+    var ss: Float32 = tmp.total()
     ss = ss / size + 1e-5
     ss = 1.0 / math.sqrt(ss)
 
@@ -543,17 +565,17 @@ fn softmax(inout x: TensorF32, start: Int, end: Int):
 
     vectorize[nelts, _max](end - start)
 
-    var ssum: Float32 = 0.0
+    var acc = Accumulator[DType.float32, nelts]()
 
     @parameter
     fn _exp[_nelts: Int](ii: Int):
-        x.simd_store[_nelts](
-            start + ii, math.exp(x.simd_load[_nelts](start + ii) - max_val)
-        )
-        ssum += x.simd_load[_nelts](start + ii).reduce_add()
+        let val = math.exp(x.simd_load[_nelts](start + ii) - max_val)
+        x.simd_store[_nelts](start + ii, val)
+        acc.accumulate(val)
 
     vectorize[nelts, _exp](end - start)
 
+    var ssum = acc.total()
     @parameter
     fn _norm[_nelts: Int](ii: Int):
         x.simd_store[_nelts](start + ii, x.simd_load[_nelts](start + ii) / ssum)
@@ -573,41 +595,26 @@ fn batch_matmul[
 ):
     @parameter
     fn compute_row(i: Int):
-        var tmp = StaticTuple[n, SIMD[DType.float32, nelts]]()
-        @parameter
-        fn init[k: Int]():
-            tmp[k] = SIMD[DType.float32, nelts](0)
-        unroll[n, init]()
+        var tmp = StaticTuple[n, Accumulator[DType.float32, nelts]]()
+        @unroll
+        for k in range(n):
+            tmp[k] = Accumulator[DType.float32, nelts]()
+
         let row_offset = i * cols
 
         @parameter
         fn dot[_nelts: Int](j: Int):
-            if _nelts < nelts:  # take care of tail array elements with length <  nelts
-                let a = A.simd_load[_nelts](j)
+            let a = A.simd_load[_nelts](j)
 
-                @parameter
-                fn _multiply_tail[k: Int]():
-                    tmp[k][0] += (
-                        a * B[k].simd_load[_nelts](row_offset + j)
-                    ).reduce_add()
-
-                unroll[n, _multiply_tail]()
-            else:
-                let a = A.simd_load[nelts](j)
-
-                @parameter
-                fn _multiply[k: Int]():
-                    tmp[k] += a * B[k].simd_load[nelts](row_offset + j)
-
-                unroll[n, _multiply]()
+            @unroll
+            for k in range(n):
+                tmp[k].accumulate(a * B[k].simd_load[_nelts](row_offset + j))
 
         vectorize[nelts, dot](cols)
 
-        @parameter
-        fn _reduce[k: Int]():
-            C[k].store(i, tmp[k].reduce_add())
-
-        unroll[n, _reduce]()
+        @unroll
+        for k in range(n):
+            C[k].store(i, tmp[k].total())
 
     parallelize[compute_row](rows, workers)
 


### PR DESCRIPTION
- use @unroll decorator where possible
- DRY _nelts < nelts checks code wherever it is used for tail handling in vectorise
  - Use a stack allocated DTypePointer so we can always load or store _nelts width SIMD vector
  - But pointer needs memset_zero so code so I created a small Accumulator struct to hide away boilerplate
  - I tried using a SIMD and inferring width to branch when widths were different but couldn't make it work so landed with the pointer approach
  - small speed gains (not a reason to merge but maybe interesting):
    - The A vector in batch_matmul is now only read once and shared for the batch.
    - reduce_add only needs to be called once at the end of the loop since we alway accumulate _nelts width exactly. Softmax was calling reduce_add() on every iteration.  
    
Llamatune results on M1 Pro: 
V1 = master, V2 = this PR

Benchmark 1: run_v1 stories15M.bin
  Time (mean ± σ):     327.2 ms ±   8.6 ms    [User: 1945.5 ms, System: 65.6 ms]
  Range (min … max):   316.4 ms … 352.2 ms    30 runs
 
Benchmark 2: run_v2 stories15M.bin
  Time (mean ± σ):     325.2 ms ±   5.6 ms    [User: 1928.7 ms, System: 65.6 ms]
  Range (min … max):   315.0 ms … 338.6 ms    30 runs
 
Benchmark 3: run_v1 stories42M.bin
  Time (mean ± σ):     756.8 ms ±  16.8 ms    [User: 4164.0 ms, System: 157.5 ms]
  Range (min … max):   732.3 ms … 811.0 ms    30 runs
 
Benchmark 4: run_v2 stories42M.bin
  Time (mean ± σ):     750.0 ms ±  23.4 ms    [User: 4110.9 ms, System: 147.9 ms]
  Range (min … max):   718.2 ms … 811.6 ms    30 runs
 
Benchmark 5: run_v1 stories110M.bin
  Time (mean ± σ):      1.979 s ±  0.020 s    [User: 11.201 s, System: 0.372 s]
  Range (min … max):    1.952 s …  2.027 s    30 runs
 
Benchmark 6: run_v2 stories110M.bin
  Time (mean ± σ):      1.969 s ±  0.023 s    [User: 11.241 s, System: 0.354 s]
  Range (min … max):    1.939 s …  2.038 s    30 runs
 
Tiny improvement but consistent so it is probably real.  I expect it is the reduce_add() removal in softmax that contributed most.