### PR TITLE
avoid data copy when reading files

### DIFF
--- a/llama2.mojo
+++ b/llama2.mojo
@@ -467,22 +467,10 @@ struct TransformerWeights:
 
 fn read_file(file_name: String, inout buf: FileBuf) raises:
     var fd = open(file_name, "r")
-    let data = fd.read()
+    var data = fd.read()
     fd.close()
-
-    let cp_size = data._buffer.size
-    let cp_buf: BufferPtrType = BufferPtrType.alloc(cp_size)
-
-    let data_ptr = data._as_ptr().bitcast[DType.uint8]()
-    
-    for i in range(cp_size):
-        cp_buf.store(i,data_ptr.load(i))
-    
-    # don't free data
-    _ = data
-
-    buf.data = cp_buf
-    buf.size = cp_size
+    buf.size = data._buffer.size
+    buf.data = data._steal_ptr().bitcast[DType.uint8]()
     buf.offset = 0
     return None
 


### PR DESCRIPTION
This both speeds up loading the models and reduced memory use.  Prior to this I think we may have had 3 sets of the weights existing at a time.   Memory usage on my M1 Pro now peaks ~8GB instead of ~12GB when running TinyLlama-1B. 