### PR TITLE
Use String, Dict, and read_bytes to shorten and simplify 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Have you ever wanted to inference a baby Llama 2 model in pure Mojo? No? Well, now you can!
 
-supported version: [Mojo 24.2.1](https://docs.modular.com/mojo/changelog#v242-2024-03-28)
+supported version: [Mojo 24.3](https://docs.modular.com/mojo/changelog#v243-2024-05-02)
 
 With the release of [Mojo](https://www.modular.com/blog/mojo-its-finally-here), I was inspired to take my Python port
 of [llama2.py](https://github.com/tairov/llama2.py) and transition it to Mojo. The result? A version that leverages

--- a/llama2.mojo
+++ b/llama2.mojo
@@ -228,7 +228,7 @@ struct Tokenizer:
         var token = wrap(token_o)
         var index = self.map_vocab_to_index.find(token)
         if index:
-            return index.value()
+            return index.value()[]
         return -1
 
 


### PR DESCRIPTION
This is based off current nightly branch (mojo 2024.4.161).  It is a demo of some clean ups that can happen now that Mojo and its stdlib have added a lot of functionality that was missing when this was originally released.  There could probably also be another round to remove TensorSlice and just use `List[TensorF32]` for each layer of weights.

The main changes are:

- replace PointerString and PointerStrings with String and List[String] respectively.
- Use a Dict to lookup token indices.  This allows removing Quicksort and binary search code.
- small changes like using Tensor's own SIMD operations and argmax.
- use `read_bytes` to handling of pointers without copying.  That means FileBuf is no longer used.
 
I am not sure this is ready to merge mostly because the of handling of special bytes  handling in `wrap` and the old print function.  I tried to persevere the functionality but haven't tested extensively.   Ideally we could get proper handling from String and if not fix it in stdlib.

Also, I think the stdlib is going to shift to `List[UInt8]` for all bytes representations, including in String.  So this change could also wait until after has happened and is incorporated.

I didn't mess with Llamatune since this is going across Mojo versions but locally there was no change in tokens / sec.  It is probably loading faster and more memory efficiently since this avoids the vocab sort and no longer reads entire `tokenizer.bin`.  